### PR TITLE
Bug Fix for strcpy

### DIFF
--- a/src/Dhcp.cpp
+++ b/src/Dhcp.cpp
@@ -9,11 +9,11 @@
 #include "Arduino.h"
 #include "utility/util.h"
 
-char HOST_NAME[] = "WIZNet";
+char HOST_NAME[MAX_HOST_NAME_SIZE + 1] = "WIZNet";
 //
 void DhcpClass::setHostName(char *dhcpHost) {
-	memset(HOST_NAME, 0, sizeof(HOST_NAME));
-	strcpy(HOST_NAME, dhcpHost);
+	HOST_NAME[MAX_HOST_NAME_SIZE] = 0;                // make sure we always have a terminated string
+	strncpy(HOST_NAME, dhcpHost, MAX_HOST_NAME_SIZE); // make sure we copy within valid array boundaries
 }
 //
 char * DhcpClass::getHostName() {

--- a/src/Dhcp.h
+++ b/src/Dhcp.h
@@ -44,7 +44,8 @@
 #define MAGIC_COOKIE		0x63825363
 #define MAX_DHCP_OPT	16
 
-//#define HOST_NAME "WIZnet"
+#define MAX_HOST_NAME_SIZE 24
+
 #define DEFAULT_LEASE	(900) //default lease time in seconds
 
 #define DHCP_CHECK_NONE         (0)


### PR DESCRIPTION
char HOST_NAME[] = "WIZNet" would limit the hostname to 6 characters, longer hostnames would corrupt memory.
Added MAX_HOST_NAME_SIZE to extend the hostname buffer, replaced strcpy by strncpy to prevent an buffer overrun.